### PR TITLE
Fix undefined function report_engagement_get_course_summary()

### DIFF
--- a/block_engagement.php
+++ b/block_engagement.php
@@ -80,12 +80,13 @@ class block_engagement extends block_base {
             return $this->content;
         }
 
+        $renderer = $this->page->get_renderer('block_engagement');
+
         $risks = report_engagement_get_course_summary($COURSE->id);
         $users = $DB->get_records_list('user', 'id', array_keys($risks), '', 'id, firstname, lastname');
 
         // Grab the items to display.
         $this->content = new stdClass();
-        $renderer = $this->page->get_renderer('block_engagement');
         $this->content->text = $renderer->user_risk_list($risks, $users);
         return $this->content;
     }


### PR DESCRIPTION
Hi there

Thanks for the plugin.

We are using Moodle v2.5.3 and the engagement block throws fatal error 'Undefined function...'.

The lib.php for the report plugin is included after calling the function 'report_engagement_get_course_summary()'

Cheers
